### PR TITLE
Limit `clone` depth

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -2,12 +2,11 @@ var bunyan = require('bunyan');
 var os     = require('os');
 var dgram  = require('dgram');
 
-function clone(obj) {
-  // we only need to clone refrence types (Object)
-  if (!(obj instanceof Object)) {
-    return obj;
-  }
-  else if (obj instanceof Date) {
+function clone(obj, depth) {
+  // we only need to clone reference types (Object)
+  if (!(obj instanceof Object) ||
+      obj instance of Date ||
+      depth > 2) {
     return obj;
   }
 
@@ -20,7 +19,7 @@ function clone(obj) {
         copy[i] = obj[i].slice(0);
     }
     else if (typeof obj[i] != 'function') {
-      copy[i] = obj[i] instanceof Object ? clone(obj[i]) : obj[i];
+      copy[i] = obj[i] instanceof Object ? clone(obj[i], depth+1) : obj[i];
     }
     else if (typeof obj[i] === 'function') {
       copy[i] = obj[i];
@@ -66,7 +65,7 @@ LogstashStream.prototype.write = function logstashWrite(entry) {
     entry = JSON.parse(entry);
   }
 
-  rec = clone(entry);
+  rec = clone(entry, 0);
 
   level = rec.level;
 


### PR DESCRIPTION
Since `bunyan` supports passing objects

    log.error { acc: acc, err: err }, "Failed to update account"

When above `acc` object contains circular reference, the `clone` function will loop endlessly. So just limit the calling depth.