### PR TITLE
added error handling/logging when server can't be reached

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -3,8 +3,6 @@ var extend = require('extend');
 var os     = require('os');
 var dgram  = require('dgram');
 
-var lastErrorTimestamp;
-
 function clone(obj, depth) {
   // we only need to clone reference types (Object)
   if (!(obj instanceof Object) ||

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -105,6 +105,10 @@ LogstashStream.prototype.send = function logstashSend(message) {
 
   if (! self.client) {
     self.client = dgram.createSocket('udp4');
+    self.client.on("error", function (err) {
+      console.log("bunyan-logstash socket connection error: " + err);
+    });
+
   }
 
   self.client.send(buf, 0, buf.length, self.port, self.host);

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -3,6 +3,8 @@ var extend = require('extend');
 var os     = require('os');
 var dgram  = require('dgram');
 
+var lastErrorTimestamp;
+
 function clone(obj, depth) {
   // we only need to clone reference types (Object)
   if (!(obj instanceof Object) ||
@@ -106,9 +108,12 @@ LogstashStream.prototype.send = function logstashSend(message) {
   if (! self.client) {
     self.client = dgram.createSocket('udp4');
     self.client.on("error", function (err) {
-      console.log("bunyan-logstash socket connection error: " + err);
+      var currentTimestamp = new Date().getTime()
+      if (!lastErrorTimestamp || currentTimestamp - lastErrorTimestamp > 10000) {
+        lastErrorTimestamp = currentTimestamp;
+        console.log("bunyan-logstash socket connection error: " + err);
+      }
     });
-
   }
 
   self.client.send(buf, 0, buf.length, self.port, self.host);

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -3,6 +3,9 @@ var extend = require('extend');
 var os     = require('os');
 var dgram  = require('dgram');
 
+// used to throttle errors loggings when sending fails
+var lastErrorTimestamp;
+
 function clone(obj, depth) {
   // we only need to clone reference types (Object)
   if (!(obj instanceof Object) ||


### PR DESCRIPTION
If the server address can't be found the whole app would die with an error in dns.js somehwere deep in node. So now we capture a possible error, log it out and throttle the logging to every 10 seconds.