### PR TITLE
unref() the udp socket so that it doesn't hold the process open

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -108,6 +108,8 @@ LogstashStream.prototype.send = function logstashSend(message) {
 
   if (! self.client) {
     self.client = dgram.createSocket('udp4');
+    self.client.unref();
+    
     self.client.on("error", function (err) {
       var currentTimestamp = new Date().getTime()
       if (!lastErrorTimestamp || currentTimestamp - lastErrorTimestamp > 10000) {


### PR DESCRIPTION
Add self.client.unref() after the createSocket() call so that the a
process using this bunyan stream can cleanly exit.  See
https://nodejs.org/api/dgram.html#dgram_socket_unref