### PR TITLE
Exposes a close method

### DIFF
--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -124,7 +124,7 @@ LogstashStream.prototype.close = function () {
   var self = this;
 
   if (self.client) {
-      self.client.close();
+    self.client.close();
   }
 };
 

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -125,8 +125,8 @@ LogstashStream.prototype.close = function () {
 
   if (self.client) {
       self.client.close();
-    }
-}
+  }
+};
 
 module.exports = {
   createStream:   createLogstashStream,

--- a/lib/logstash.js
+++ b/lib/logstash.js
@@ -120,6 +120,13 @@ LogstashStream.prototype.send = function logstashSend(message) {
   self.client.send(buf, 0, buf.length, self.port, self.host);
 };
 
+LogstashStream.prototype.close = function () {
+  var self = this;
+
+  if (self.client) {
+      self.client.close();
+    }
+}
 
 module.exports = {
   createStream:   createLogstashStream,


### PR DESCRIPTION
Allows a client to `close()` the stream when the process is done. This is an alternative to #8 which would leave the socket open.